### PR TITLE
HUB-4306 Enable Claude-powered PR reviews via reusable workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,26 @@
+name: Claude PR Review
+
+on:
+  issue_comment:
+    types: [created]
+
+# Ensure only one review runs per PR at a time
+concurrency:
+  group: claude-review-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  claude-review:
+    # Only run on PR comments that mention "@claude" anywhere
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude')
+
+    # Call the centralized reusable workflow from the .github organization repository
+    uses: quantivly/.github/.github/workflows/claude-review.yml@master
+    secrets: inherit  # Pass all organization secrets to the reusable workflow


### PR DESCRIPTION
## Summary
Adds automated Claude code reviews triggered by @claude comments on PRs.

## Changes
- Adds `.github/workflows/claude-review.yml` (26 lines, matches template)
- No code changes - pure infrastructure addition

## Integration Details
- **Trigger**: Comment `@claude` on any open PR
- **Reviews**: Security, logic, quality, testing, performance
- **Linear**: Auto-fetches issue context if PR title contains Linear ID
- **Cost**: ~$0.50-1.00 per review (org-paid, prompt caching enabled)

## Testing
- Workflow tested in `sre-core` repository (PR #1182)
- Central infrastructure in `quantivly/.github` fully operational
- Secrets automatically inherited from organization

## Documentation
See [Claude Integration Guide](https://github.com/quantivly/.github/blob/master/docs/claude-integration-guide.md)

## Checklist
- [x] Workflow file matches official template exactly
- [x] No custom modifications needed
- [x] Organization secrets already configured
- [x] Documentation reviewed